### PR TITLE
feat: 장바구니 CRUD 구현 - Entity & Repository

### DIFF
--- a/src/main/java/shop/chaekmate/core/cart/entity/Cart.java
+++ b/src/main/java/shop/chaekmate/core/cart/entity/Cart.java
@@ -12,16 +12,12 @@ import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.SQLRestriction;
 import shop.chaekmate.core.common.entity.BaseEntity;
 import shop.chaekmate.core.member.entity.Member;
 
 @Getter
 @Table(name = "cart")
-@SQLRestriction("deleted_at is null")
 @NoArgsConstructor(access = PROTECTED)
-@SQLDelete(sql = "UPDATE cart SET deleted_at = CURRENT_TIMESTAMP WHERE id = ?")
 @Entity
 public class Cart extends BaseEntity {
 
@@ -30,6 +26,14 @@ public class Cart extends BaseEntity {
     private Long id;
 
     @OneToOne(fetch = LAZY)
-    @JoinColumn(name = "member_id", nullable = false)
+    @JoinColumn(name = "member_id", unique = true)
     private Member member;
+
+    public static Cart create(Member member) {
+        return new Cart(member);
+    }
+
+    private Cart(Member member) {
+        this.member = member;
+    }
 }

--- a/src/main/java/shop/chaekmate/core/cart/entity/CartItem.java
+++ b/src/main/java/shop/chaekmate/core/cart/entity/CartItem.java
@@ -10,20 +10,16 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.SQLRestriction;
 import shop.chaekmate.core.book.entity.Book;
+import shop.chaekmate.core.cart.exception.cartitem.InvalidCartItemQuantityException;
 import shop.chaekmate.core.common.entity.BaseEntity;
 
 @Getter
 @Table(name = "cart_item")
-@SQLRestriction("deleted_at is null")
 @NoArgsConstructor(access = PROTECTED)
-@SQLDelete(sql = "UPDATE cart_item SET deleted_at = CURRENT_TIMESTAMP WHERE id = ?")
 @Entity
 public class CartItem extends BaseEntity {
 
@@ -35,10 +31,30 @@ public class CartItem extends BaseEntity {
     @JoinColumn(name = "cart_id", nullable = false)
     private Cart cart;
 
-    @OneToOne(fetch = LAZY)
+    @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "book_id", nullable = false)
     private Book book;
 
     @Column(nullable = false)
     private int quantity;
+
+    // 장바구니에 도서를 처음 담는 시점에 생성됨
+    // 장바구니 아이템의 최소 수량 규칙: 항상 1부터 시작
+    public static CartItem create(Cart cart, Book book) {
+        return new CartItem(cart, book, 1);
+    }
+
+    public void updateQuantity(int quantity) {
+        if (quantity <= 0) {
+            throw new InvalidCartItemQuantityException();
+        }
+
+        this.quantity = quantity;
+    }
+
+    private CartItem(Cart cart, Book book, int quantity) {
+        this.cart = cart;
+        this.book = book;
+        this.quantity = quantity;
+    }
 }

--- a/src/main/java/shop/chaekmate/core/cart/exception/cartitem/CartItemErrorCode.java
+++ b/src/main/java/shop/chaekmate/core/cart/exception/cartitem/CartItemErrorCode.java
@@ -1,0 +1,21 @@
+package shop.chaekmate.core.cart.exception.cartitem;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import shop.chaekmate.core.common.exception.BaseErrorCode;
+
+@Getter
+public enum CartItemErrorCode implements BaseErrorCode {
+
+    INVALID_QUANTITY(HttpStatus.BAD_REQUEST, "CARTITEM-400", "유효하지 않은 장바구니 아이템 수량입니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+
+    CartItemErrorCode(HttpStatus status, String code, String message) {
+        this.status = status;
+        this.code = code;
+        this.message = message;
+    }
+}

--- a/src/main/java/shop/chaekmate/core/cart/exception/cartitem/InvalidCartItemQuantityException.java
+++ b/src/main/java/shop/chaekmate/core/cart/exception/cartitem/InvalidCartItemQuantityException.java
@@ -1,0 +1,9 @@
+package shop.chaekmate.core.cart.exception.cartitem;
+
+import shop.chaekmate.core.common.exception.CoreException;
+
+public class InvalidCartItemQuantityException extends CoreException {
+  public InvalidCartItemQuantityException() {
+    super(CartItemErrorCode.INVALID_QUANTITY);
+  }
+}

--- a/src/main/java/shop/chaekmate/core/cart/repository/CartItemRepository.java
+++ b/src/main/java/shop/chaekmate/core/cart/repository/CartItemRepository.java
@@ -1,7 +1,18 @@
 package shop.chaekmate.core.cart.repository;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import shop.chaekmate.core.cart.entity.CartItem;
 
-public interface CartItemRepository extends JpaRepository<CartItem, Long> {
+public interface CartItemRepository extends JpaRepository<CartItem, Long>, CartItemRepositoryCustom {
+    // 조회
+    boolean existsByCartIdAndBookId(Long cartId, Long bookId);
+
+    // 정렬
+    List<CartItem> findAllByCartIdOrderByCreatedAtAsc (Long cartId);
+    List<CartItem> findAllByCartIdOrderByCreatedAtDesc (Long cartId);
+
+    // 삭제
+    int deleteByCartIdAndBookId(Long cartId, Long bookId);
+    int deleteAllByCartId(Long cartId);
 }

--- a/src/main/java/shop/chaekmate/core/cart/repository/CartItemRepositoryCustom.java
+++ b/src/main/java/shop/chaekmate/core/cart/repository/CartItemRepositoryCustom.java
@@ -1,0 +1,9 @@
+package shop.chaekmate.core.cart.repository;
+
+import java.util.List;
+import shop.chaekmate.core.cart.entity.CartItem;
+
+public interface CartItemRepositoryCustom {
+    List<CartItem> findAllByCartIdOrderByBookTitleAsc(Long cartId);
+    List<CartItem> findAllByCartIdOrderByBookTitleDesc(Long cartId);
+}

--- a/src/main/java/shop/chaekmate/core/cart/repository/CartRepository.java
+++ b/src/main/java/shop/chaekmate/core/cart/repository/CartRepository.java
@@ -1,7 +1,14 @@
 package shop.chaekmate.core.cart.repository;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import shop.chaekmate.core.cart.entity.Cart;
 
 public interface CartRepository extends JpaRepository<Cart, Long> {
+    // 조회
+    Optional<Cart> findByMemberId(Long memberId);
+
+    // 삭제
+    // CASCADE 옵션 설정에 따라 장바구니 아이템도 함께 삭제되는지 확인 필요
+    int deleteByMemberId(Long memberId);
 }

--- a/src/main/java/shop/chaekmate/core/cart/repository/impl/CartItemRepositoryImpl.java
+++ b/src/main/java/shop/chaekmate/core/cart/repository/impl/CartItemRepositoryImpl.java
@@ -1,0 +1,43 @@
+package shop.chaekmate.core.cart.repository.impl;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import shop.chaekmate.core.book.entity.QBook;
+import shop.chaekmate.core.cart.entity.CartItem;
+import shop.chaekmate.core.cart.entity.QCartItem;
+import shop.chaekmate.core.cart.repository.CartItemRepositoryCustom;
+
+@RequiredArgsConstructor
+@Repository
+public class CartItemRepositoryImpl implements CartItemRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<CartItem> findAllByCartIdOrderByBookTitleAsc(Long cartId) {
+        QCartItem cartItem = QCartItem.cartItem;
+        QBook book = QBook.book;
+
+        return queryFactory
+                .selectFrom(cartItem)
+                .join(cartItem.book, book).fetchJoin()
+                .where(cartItem.cart.id.eq(cartId))
+                .orderBy(book.title.asc())
+                .fetch();
+    }
+
+    @Override
+    public List<CartItem> findAllByCartIdOrderByBookTitleDesc(Long cartId) {
+        QCartItem cartItem = QCartItem.cartItem;
+        QBook book = QBook.book;
+
+        return queryFactory
+                .selectFrom(cartItem)
+                .join(cartItem.book, book).fetchJoin()
+                .where(cartItem.cart.id.eq(cartId))
+                .orderBy(book.title.desc())
+                .fetch();
+    }
+}

--- a/src/test/java/shop/chaekmate/core/cart/repository/CartItemRepositoryTest.java
+++ b/src/test/java/shop/chaekmate/core/cart/repository/CartItemRepositoryTest.java
@@ -1,0 +1,139 @@
+package shop.chaekmate.core.cart.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import shop.chaekmate.core.book.entity.Book;
+import shop.chaekmate.core.book.repository.BookRepository;
+import shop.chaekmate.core.cart.entity.Cart;
+import shop.chaekmate.core.cart.entity.CartItem;
+import shop.chaekmate.core.common.config.JpaAuditingConfig;
+import shop.chaekmate.core.common.config.QueryDslConfig;
+import shop.chaekmate.core.member.entity.Member;
+import shop.chaekmate.core.member.entity.type.PlatformType;
+import shop.chaekmate.core.member.repository.MemberRepository;
+
+@ActiveProfiles("test")
+@Import({QueryDslConfig.class, JpaAuditingConfig.class})
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@DataJpaTest
+public class CartItemRepositoryTest {
+
+    @Autowired
+    private CartItemRepository cartItemRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private CartRepository cartRepository;
+
+    @Autowired
+    private BookRepository bookRepository;
+
+    private Member member;
+    private Cart cart;
+    private Book bookA;
+    private Book bookB;
+    private Book bookC;
+
+    @BeforeEach
+    void setup() {
+        this.member = new Member("testId", "testPassword", "testName", "010-1234-5678", "test@examplet.com", LocalDate.of(1998, 1, 1), PlatformType.LOCAL);
+        this.memberRepository.save(member);
+
+        this.cart = Cart.create(member);
+        this.cartRepository.save(cart);
+
+        this.bookA = Book.builder()
+                .title("A")
+                .index("목차")
+                .description("설명")
+                .author("테스트 저자")
+                .publisher("테스트 출판사")
+                .publishedAt(LocalDateTime.of(2024, 1, 1, 0, 0))
+                .isbn("9781234567890")
+                .price(10000)
+                .salesPrice(9000)
+                .isWrappable(true)
+                .views(0)
+                .isSaleEnd(false)
+                .stock(100)
+                .build();
+
+        this.bookB = Book.builder()
+                .title("B")
+                .index("목차")
+                .description("설명")
+                .author("테스트 저자")
+                .publisher("테스트 출판사")
+                .publishedAt(LocalDateTime.of(2024, 1, 1, 0, 0))
+                .isbn("9781234567891")
+                .price(10000)
+                .salesPrice(9000)
+                .isWrappable(true)
+                .views(0)
+                .isSaleEnd(false)
+                .stock(100)
+                .build();
+
+        this.bookC = Book.builder()
+                .title("C")
+                .index("목차")
+                .description("설명")
+                .author("테스트 저자")
+                .publisher("테스트 출판사")
+                .publishedAt(LocalDateTime.of(2024, 1, 1, 0, 0))
+                .isbn("9781234567892")
+                .price(10000)
+                .salesPrice(9000)
+                .isWrappable(true)
+                .views(0)
+                .isSaleEnd(false)
+                .stock(100)
+                .build();
+
+        this.bookRepository.save(this.bookA);
+        this.bookRepository.save(this.bookB);
+        this.bookRepository.save(this.bookC);
+
+        CartItem item1 = CartItem.create(this.cart, this.bookA);
+        CartItem item2 = CartItem.create(this.cart, this.bookB);
+        CartItem item3 = CartItem.create(this.cart, this.bookC);
+
+        this.cartItemRepository.save(item1);
+        this.cartItemRepository.save(item2);
+        this.cartItemRepository.save(item3);
+    }
+
+    @Test
+    void 도서명_기준_장바구니_아이템_오름차순_조회() {
+        List<CartItem> items = this.cartItemRepository.findAllByCartIdOrderByCreatedAtAsc(this.cart.getId());
+
+        assertThat(items).hasSize(3);
+        assertThat(items.get(0).getBook().getTitle()).isEqualTo("A");
+        assertThat(items.get(1).getBook().getTitle()).isEqualTo("B");
+        assertThat(items.get(2).getBook().getTitle()).isEqualTo("C");
+    }
+
+    @Test
+    void 도서명_기준_장바구니_아이템_내림차순_조회() {
+        List<CartItem> items = this.cartItemRepository.findAllByCartIdOrderByCreatedAtDesc(this.cart.getId());
+
+        assertThat(items).hasSize(3);
+        assertThat(items.get(0).getBook().getTitle()).isEqualTo("C");
+        assertThat(items.get(1).getBook().getTitle()).isEqualTo("B");
+        assertThat(items.get(2).getBook().getTitle()).isEqualTo("A");
+    }
+}


### PR DESCRIPTION
## 🔥 연관 이슈

- 없음

## 📝 작업 요약

- 장바구니 및 장바구니 아이템 Entity & Repository 구현
- 장바구니 아이템 Repository : QueryDSL 활용한 도서명 기준 정렬 메서드 테스트

## ⏰ 소요 시간

- 5일 (25/11/06 목 ~ 25/11/10 월)
- 장바구니 설계에 너무 많은 시간 소요
  - Redis와 DB를 모두 고려해 구현하려다 보니 오히려 더 꼬임
  - 우선 DB만 고려해 빠르게 구현하는 방향으로 수정

## 🔎 작업 상세 설명

- 장바구니 & 장바구니 아이템 공통 : 
  - Entity : 
    - 회원 삭제 시 Cascade Soft Delete 대신 Cascade Hard Delete로 수정
      - @SQLRestriction & @SQLDelete 어노테이션 제거
    - 생성 목적 및 방법에 대한 표현과 인스턴스 관리를 위해 정적 팩토리 메서드 사용 

---

- 장바구니 : 
  - Entity : 
    - 회원과의 일대일 관계를 명확히 하기 위해 UNIQUE 제약조건 추가 (DB 반영O)
  - Repository : 
    - 회원 기준 조회 및 삭제 쿼리 메서드 작성

---

- 장바구니 아이템 : 
  - Entity : 
    - 도서와의 연관관계를 기존 일대일에서 일대다 (즉, 하나의 도서는 여러 개의 장바구니 아이템에 담길 수 있음)로 수정
    - 장바구니 아이템이 처음으로 장바구니에 담길 때 (즉, 장바구니 아이템이 처음 생성될 때) 수량은 무조건 최소 1부터 시작
    - 수량 업데이트 메서드 추가 (우선 최소 재고량인 0 이하인 경우, 예외)
  - Repository : 
    - 특정 도서 존재 여부 판별 쿼리 메서드 작성
    - 장바구니 비우기 및 특정 도서 삭제 쿼리 메서드 작성
    - QueryDSL을 활용한 도서명 기준 장바구니 아이템 정렬 메서드 구현 (FETCH Join)
      - 테스트 작성 및 통과 확인

## 🌟 논의 사항

- 우선 Entity & Repository 구현 리뷰를 받고 싶어 먼저 PR을 올립니다
  - 잠깐이나마 확인해주시고, 피드백 주시면 감사하겠습니다.