### PR TITLE
feat:AOP기반 권한 체크 및 커스텀어노테이션 구현

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,6 +149,11 @@
             <version>2.0.0</version>
         </dependency>
 
+        <!-- AOP -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-aop</artifactId>
+        </dependency>
     </dependencies>
 
     <dependencyManagement>

--- a/src/main/java/shop/chaekmate/core/common/annotation/RequiredAdmin.java
+++ b/src/main/java/shop/chaekmate/core/common/annotation/RequiredAdmin.java
@@ -1,0 +1,11 @@
+package shop.chaekmate.core.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RequiredAdmin {
+}

--- a/src/main/java/shop/chaekmate/core/common/annotation/RequiredMember.java
+++ b/src/main/java/shop/chaekmate/core/common/annotation/RequiredMember.java
@@ -1,0 +1,11 @@
+package shop.chaekmate.core.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RequiredMember {
+}

--- a/src/main/java/shop/chaekmate/core/common/aop/RoleCheckAspect.java
+++ b/src/main/java/shop/chaekmate/core/common/aop/RoleCheckAspect.java
@@ -1,0 +1,78 @@
+package shop.chaekmate.core.common.aop;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+import shop.chaekmate.core.common.exception.CommonErrorCode;
+import shop.chaekmate.core.common.exception.CoreException;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class RoleCheckAspect {
+
+    private static final String X_MEMBER_ID = "X-Member-Id";
+    private static final String X_USER_ROLE = "X-User-Role";
+
+    @Around("@annotation(shop.chaekmate.core.common.annotation.RequiredMember)")
+    public Object checkMember(ProceedingJoinPoint joinPoint) throws Throwable {
+        HttpServletRequest request = getRequest();
+        if (request == null) {
+            throw new CoreException(CommonErrorCode.TOKEN_INVALID);
+        }
+
+        String memberId = request.getHeader(X_MEMBER_ID);
+        String role = request.getHeader(X_USER_ROLE);
+        if (memberId == null || role == null) {
+            throw new CoreException(CommonErrorCode.TOKEN_INVALID);
+        }
+
+        // USER 또는 ADMIN이면 통과
+        if ("USER".equals(role) || "ADMIN".equals(role)) {
+            log.debug("회원 권한 체크 통과: memberId={}, role={}", memberId, role);
+            return joinPoint.proceed();
+        }
+
+        throw new CoreException(CommonErrorCode.TOKEN_INVALID);
+    }
+
+    @Around("@annotation(shop.chaekmate.core.common.annotation.RequiredAdmin)")
+    public Object checkAdmin(ProceedingJoinPoint joinPoint) throws Throwable {
+        HttpServletRequest request = getRequest();
+        if (request == null) {
+            throw new CoreException(CommonErrorCode.TOKEN_INVALID);
+        }
+
+        String memberId = request.getHeader(X_MEMBER_ID);
+        String role = request.getHeader(X_USER_ROLE);
+        if (memberId == null || role == null) {
+            throw new CoreException(CommonErrorCode.TOKEN_INVALID);
+        }
+
+        // ADMIN 권한 체크
+        if ("ADMIN".equals(role)) {
+            log.debug("관리자 권한 체크 통과: memberId={}", memberId);
+            return joinPoint.proceed();
+        }
+
+        throw new CoreException(CommonErrorCode.TOKEN_INVALID);
+    }
+
+    private HttpServletRequest getRequest() {
+        ServletRequestAttributes attributes =
+                (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+        if (attributes == null) {
+            return null;
+        }
+
+        return attributes.getRequest();
+    }
+}
+

--- a/src/main/java/shop/chaekmate/core/common/exception/CommonErrorCode.java
+++ b/src/main/java/shop/chaekmate/core/common/exception/CommonErrorCode.java
@@ -8,6 +8,7 @@ public enum CommonErrorCode implements BaseErrorCode{
 
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "valid-400", "요청 값이 유효하지 않습니다."),
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "AUTH-401", "인증 정보가 유효하지 않습니다."),
+    TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "AUTH-401", "토큰이 유효하지 않습니다."),
     METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "SERVER-405", "허용되지 않은 요청 메서드입니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "SERVER-500", "서버 내부 오류가 발생했습니다.");
 


### PR DESCRIPTION
## 🔥 연관 이슈

close: #

## 📝 작업 요약
AOP 기반 권한 체크 기능을 구현하여 게이트웨이에서 전달된 헤더 정보로 권한을 검증하는 기능 추가

## ⏰ 소요 시간
1일

## 🔎 작업 상세 설명
AOP 기반 권한 체크 구현
- RoleCheckAspect: 게이트웨이에서 전달된 `X-Member-Id`, `X-User-Role` 헤더를 읽어서 권한 체크
- `@RequiredMember` 어노테이션: USER 또는 ADMIN 권한이 필요
- `@RequiredAdmin` 어노테이션: ADMIN 권한만 허용
- 헤더가 없거나 권한이 부족하면 `CoreException(TOKEN_INVALID)` 발생

커스텀 어노테이션 추가
- `@RequiredMember`: 메서드에 USER 또는 ADMIN 권한이 필요함을 표시
- `@RequiredAdmin`: 메서드에 ADMIN 권한이 필요함을 표시

## 🌟 논의 사항
추가로 core서버에서 코드 작성하시는 분들 모두 참고 바랍니다.
어노테이션 사용 예시

1. 일반 회원 또는 관리자 접근 허용

@RequiredMember
@GetMapping("/orders")
@RequiredMember  // USER 또는 ADMIN 접근 가능
public ResponseEntity<OrderResponse> getOrders() {
     ...
}

2. 관리자만 접근 허용

@RequiredAdmin
@PostMapping("/admin/books")
@RequiredAdmin  // ADMIN만 접근 가능
public ResponseEntity<BookResponse> createBook() {
    ...
}

3. 인증 불필요 (비회원 접근 가능)
 
어노테이션 없음
@GetMapping("/books")
// 어노테이션 없음 = 누구나 접근 가능
public ResponseEntity<BookResponse> getBooks() {
    ...
}
