### PR TITLE
장바구니 리팩토링 : 헤더 장바구니 아이템 개수 배지 표현 기능 추가

### DIFF
--- a/src/main/java/shop/chaekmate/core/cart/controller/CartController.java
+++ b/src/main/java/shop/chaekmate/core/cart/controller/CartController.java
@@ -21,6 +21,7 @@ import shop.chaekmate.core.cart.dto.CartItemReadDto;
 import shop.chaekmate.core.cart.dto.CartItemUpdateDto;
 import shop.chaekmate.core.cart.dto.request.CartItemCreateRequest;
 import shop.chaekmate.core.cart.dto.request.CartItemUpdateRequest;
+import shop.chaekmate.core.cart.dto.response.CartItemCountResponse;
 import shop.chaekmate.core.cart.dto.response.CartItemListAdvancedResponse;
 import shop.chaekmate.core.cart.dto.response.CartItemListResponse;
 import shop.chaekmate.core.cart.dto.response.CartItemUpdateResponse;
@@ -96,6 +97,38 @@ public class CartController {
         );
 
         CartItemListAdvancedResponse response = this.cartService.getCartItemsWithBookInfo(dto);
+
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 장바구니 아이템 개수 조회
+     * - 장바구니에 담긴 도서 종류의 개수를 반환함
+     *
+     * <p>회원의 경우 X-Member-Id 헤더를 통해, 비회원의 경우 Guest-Id 쿠키를 통해
+     * 장바구니를 식별하며, 동일한 도서의 수량과 무관하게 도서 종류만 카운트함</p>
+     *
+     * <p>동일한 도서의 수량과 무관하게 도서 종류만 카운트함</p>
+     *
+     * <p>예시: 책A 2권, 책B 3권 → count = 2</p>
+     *
+     * @param memberId  회원 식별자(헤더), 없으면 비회원으로 간주
+     * @param guestId   비회원 식별자(쿠키), 회원일 경우 무시됨
+     * @return          장바구니 내 도서 종류 개수 응답
+     */
+    @GetMapping("/carts/item-count")
+    public ResponseEntity<CartItemCountResponse> getCartItemCount(
+            @RequestHeader(value = "X-Member-Id", required = false) Long memberId,
+            @CookieValue(name = "Guest-Id", required = false) String guestId)
+    {
+        String resolvedGuestId = (Objects.isNull(memberId)) ? guestId : null;
+
+        CartItemReadDto dto = new CartItemReadDto(
+                memberId,
+                resolvedGuestId
+        );
+
+        CartItemCountResponse response = this.cartService.getCartItemCount(dto);
 
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/shop/chaekmate/core/cart/dto/response/CartItemCountResponse.java
+++ b/src/main/java/shop/chaekmate/core/cart/dto/response/CartItemCountResponse.java
@@ -1,0 +1,6 @@
+package shop.chaekmate.core.cart.dto.response;
+
+public record CartItemCountResponse(
+        int count
+) {
+}

--- a/src/main/java/shop/chaekmate/core/cart/repository/CartRedisRepository.java
+++ b/src/main/java/shop/chaekmate/core/cart/repository/CartRedisRepository.java
@@ -71,6 +71,25 @@ public class CartRedisRepository {
         return Objects.nonNull(value) ? value.toString() : null;
     }
 
+    /**
+     * 장바구니 내 아이템 종류 개수를 조회함
+     *
+     * <p>참고:
+     * - HLEN은 hash의 모든 field 개수를 반환하므로, ownerId field 제외
+     * - 전체 field 개수 - 1 (ownerId) = 실제 도서 아이템 개수
+     *
+     * @param cartId 장바구니 ID
+     * @return 장바구니 내 도서 종류 개수
+     */
+    public int getCartItemSize(String cartId) {
+        String key = CART_PREFIX + cartId;
+        long size = this.hashOperations.size(key);  // HLEN
+
+        // 실제 아이템 (종류) 개수 반환
+        // - size == 0 --> 장바구니가 비어있거나 존재하지 않음
+        return (size > 0) ? (int) (size-1) : 0;
+    }
+
     /* =========================== 장바구니 아이템 =========================== */
 
     /**
@@ -93,6 +112,8 @@ public class CartRedisRepository {
      * @param bookId 도서 ID
      * @return 수량, 없으면 null
      */
+
+    // 실제 사용X
     public Integer getCartItem(String cartId, Long bookId) {
         String key = CART_PREFIX + cartId;
         String bookField = BOOK_PREFIX + bookId;


### PR DESCRIPTION
## 🔥 연관 이슈

## 📝 작업 요약

> 모든 화면 헤더 장바구니 아이템 개수 배지 표현 기능 추가

## ⏰ 소요 시간

> 2일

## 🔎 작업 상세 설명

- Front : ControllerAdvice 활용
  - Response DTO "CartItemCountResponse" 추가
  - Repository "getCartItemSize" 메서드 추가 
    - 여기서의 "개수"는 "장바구니에 담긴 도서의 종류 개수"를 의미함
    - 예: 책A 1권, 책B 2권 --> 개수 = 2 (A, B)
    - 예: 책A 1권, 책B 2권, 책C 3권 --> 개수 = 3 (A, B, C)
  - Service "getCartItemCount" 메서드 추가
  - Controller "getCartItemCount" 메서드 추가
    - Postman API Test 수행 (O)

## 🌟 논의 사항
